### PR TITLE
NULL initialize GError

### DIFF
--- a/ext/gda/gda.c
+++ b/ext/gda/gda.c
@@ -16,7 +16,7 @@ static VALUE parse(VALUE self, VALUE sql)
 {
     GdaSqlParser * parser;
     GdaStatement * stmt;
-    GError * error;
+    GError * error = NULL;
     const gchar * rest;
 
     Data_Get_Struct(self, GdaSqlParser, parser);


### PR DESCRIPTION
NULL initialize GError before tying to parse to avoid a GLib warning, like this:

```
(process:21877): GLib-WARNING **: GError set over the top of a previous GError or uninitialized memory.                                              
This indicates a bug in someone's code. You must ensure an error is NULL before it's set.                                                                
The overwriting error message was: SQL code does not contain any statement                                                                                
*** RuntimeError Exception: error parsing sql

```
