### PR TITLE
Undefine T_DATA allocators for Ruby 3.2 compatibility

### DIFF
--- a/ext/gda/gda_nodes.c
+++ b/ext/gda/gda_nodes.c
@@ -419,6 +419,7 @@ void Init_gda_nodes()
     mNodes = rb_define_module_under(mGDA, "Nodes");
 
     cNode = rb_define_class_under(mNodes, "Node", rb_cObject);
+    rb_undef_alloc_func(cNode);
 
     cSelect = rb_define_class_under(mNodes, "Select", cNode);
     rb_define_method(cSelect, "distinct?", distinct_p, 0);

--- a/ext/gda/gda_provider.c
+++ b/ext/gda/gda_provider.c
@@ -52,6 +52,7 @@ static VALUE quote_str(VALUE self, VALUE str)
 void Init_gda_provider()
 {
     cProvider = rb_define_class_under(mSQL, "Provider", rb_cObject);
+    rb_undef_alloc_func(cProvider);
     rb_define_singleton_method(cProvider, "find", find, 1);
     rb_define_method(cProvider, "name", name, 0);
     rb_define_method(cProvider, "parser", parser, 0);

--- a/ext/gda/gda_statement.c
+++ b/ext/gda/gda_statement.c
@@ -49,6 +49,9 @@ void Init_gda_statement()
     cStatement = rb_define_class_under(mSQL, "Statement", rb_cObject);
     cStructure = rb_define_class_under(mSQL, "Structure", rb_cObject);
 
+    rb_undef_alloc_func(cStatement);
+    rb_undef_alloc_func(cStructure);
+
     rb_define_method(cStatement, "serialize", serialize, 0);
     rb_define_method(cStatement, "structure", structure, 0);
     rb_define_method(cStructure, "ast", ast, 0);


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/18007

@tenderlove @rafaelfranca 