### PR TITLE
Fix styling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * http://github.com/tenderlove/gda
 
-## DESCRIPTION:
+## DESCRIPTION
 
 An SQL parser. Wraps libgda in a loving embrace to give you a ruby level SQL
 parser.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,39 @@
-= gda
+# gda
 
 * http://github.com/tenderlove/gda
 
-== DESCRIPTION:
+## DESCRIPTION:
 
 An SQL parser. Wraps libgda in a loving embrace to give you a ruby level SQL
 parser.
 
-== SYNOPSIS:
+# SYNOPSIS
 
-  parser = GDA::SQL::Parser.new
+```ruby
+parser = GDA::SQL::Parser.new
 
-  stmt = parser.parse 'SELECT * FROM FOO WHERE 1 = 1 GROUP BY omg HAVING omg(id) < 2 ORDER BY foo, bar LIMIT 50 OFFSET 2'
+stmt = parser.parse 'SELECT * FROM FOO WHERE 1 = 1 GROUP BY omg HAVING omg(id) < 2 ORDER BY foo, bar LIMIT 50 OFFSET 2'
 
-  stmt.ast.each do |node|
-    p node
-  end
+stmt.ast.each do |node|
+  p node
+end
 
-  puts stmt.ast.to_dot
+puts stmt.ast.to_dot
+```
 
-== HACKING:
+## HACKING
 
     $ brew install libgda
     $ gem install hoe rake-compiler
     $ rake
 
-== INSTALL:
+## INSTALL
 
-* brew install libgda
-* gem install gda
 
-== LICENSE:
+    $ brew install libgda
+    $ gem install gda
+
+## LICENSE
 
 (The MIT License)
 


### PR DESCRIPTION
Looks kinda like it was rdoc originally?

- Fixed headers
- Consistent style for hacking & install
- Put code example in fenced code block with syntax highlighting