### PR TITLE
Require libgda-6.0

### DIFF
--- a/ext/gda/extconf.rb
+++ b/ext/gda/extconf.rb
@@ -14,7 +14,7 @@ the dependency.
 MSG
 end
 
-pkg_config 'libgda-5.0'
+pkg_config 'libgda-6.0'
 find_header('libgda/sql-parser/gda-sql-parser.h') || asplode("libgda")
 
 create_makefile 'gda'


### PR DESCRIPTION
Homebrew upgraded their required version of libgda from 5.0 to 6.0 https://github.com/Homebrew/homebrew-core/commit/0a684fbd08e6878452ef3f7f06c3d517594822b3

This has started causing issues for our macOS based engineers. This updates the `pkg_config` to search for libgda 6.0 instead of 5.0 which I have confirmed fixes the issue.

This should be accompanied by an appropriate version bump when publishing, though I'm unsure if a major or minor makes the most sense.