### PR TITLE
Update failure message when gda

### DIFF
--- a/ext/gda/extconf.rb
+++ b/ext/gda/extconf.rb
@@ -8,7 +8,7 @@ dir_config 'libgda'
 
 def asplode missing
   abort <<-MSG
-#{missing} is missing. Try 'brew install libgda' if you are on OSX and have homebrew installed.
+#{missing} is missing. Try 'brew install pkg-config libgda' if you are on OSX and have homebrew installed.
 You can also check https://github.com/GNOME/libgda for more info on how to install
 the dependency.
 MSG


### PR DESCRIPTION
It's possible for this line to fail if pkg-config hasn't been brew installed, or if libgda hasn't been brew installed which provides the file for pkg-config to read.

Fixes https://github.com/tenderlove/gda/issues/9