### PR TITLE
Support both gda 5.x and 6.x (with CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgda-5.0
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         ruby: [ ruby-head, '3.1', '3.0', '2.7', '2.6', '2.5' ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install packages
         run: |
           sudo apt-get update
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install packages (macos)
         run: brew install libgda # NOTE: current libgda is 6.0
         if: matrix.os == 'macos'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ ruby-head, '3.1', '3.0', '2.7', '2.6', '2.5' ]
+        ruby: [ ruby-head, '3.2', '3.1', '3.0', '2.7', '2.6', '2.5' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
   platforms:
     strategy:
       matrix:
-        os: [macos, windows]
+        os: [macos]
         ruby: ['2.5']
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install packages (macos)
+        run: brew install libgda # NOTE: current libgda is 6.0
+        if: matrix.os == 'macos'
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/ext/gda/extconf.rb
+++ b/ext/gda/extconf.rb
@@ -14,14 +14,12 @@ the dependency.
 MSG
 end
 
-libgda = false
-%w(5.0 6.0).each do |version|
-  pkg_config "libgda-#{version}"
-  libgda = find_header('libgda/sql-parser/gda-sql-parser.h')
+available_libgda_pkg_config = %w(5.0 6.0).find do |pkg_config_version|
+  pkg_config "libgda-#{pkg_config_version}"
+  find_header('libgda/sql-parser/gda-sql-parser.h')
 end
 
-asplode("libgda") unless libgda
-
+asplode("libgda") unless available_libgda_pkg_config
 create_makefile 'gda'
 
 # :startdoc:

--- a/ext/gda/extconf.rb
+++ b/ext/gda/extconf.rb
@@ -14,10 +14,14 @@ the dependency.
 MSG
 end
 
-pkg_config 'libgda-5.0'
-find_header('libgda/sql-parser/gda-sql-parser.h') || asplode("libgda")
+libgda = false
+%w(5.0 6.0).each do |version|
+  pkg_config "libgda-#{version}"
+  libgda = find_header('libgda/sql-parser/gda-sql-parser.h')
+end
+
+asplode("libgda") unless libgda
 
 create_makefile 'gda'
-
 
 # :startdoc:

--- a/ext/gda/extconf.rb
+++ b/ext/gda/extconf.rb
@@ -14,9 +14,11 @@ the dependency.
 MSG
 end
 
-available_libgda_pkg_config = %w(5.0 6.0).find do |pkg_config_version|
+available_libgda_pkg_config = nil
+%w(5.0 6.0).each do |pkg_config_version|
   pkg_config "libgda-#{pkg_config_version}"
-  find_header('libgda/sql-parser/gda-sql-parser.h')
+  available_libgda_pkg_config = find_header('libgda/sql-parser/gda-sql-parser.h')
+  break if available_libgda_pkg_config
 end
 
 asplode("libgda") unless available_libgda_pkg_config


### PR DESCRIPTION
This patch is basically the same as #14, but modified to allow CI to pass.
https://github.com/sue445/gda/pull/1

cc. @technicalpickles

* on Ubuntu runner
  * install libgda-5.0
  * libgda-6.0 doesn't found on apt packages 😢 
* on macos runner
  * install libgda-6.0
* on windows runner
  * libgda package doesn't found on chocolatey. So I dropped 😢 
  * https://community.chocolatey.org/packages?q=libgda
  * https://community.chocolatey.org/packages?q=gda

A bit odd, but I confirm that it can be tested on CI with both libgda-5.0 and libgda-6.0

The following other corrections have been made.

* Fix deprecation warning on GitHub Actions
* CI against for ruby 3.2