### PR TITLE
Replace '<<-' heredoc operator with squiggly syntax for better left alignment

### DIFF
--- a/ext/gda/extconf.rb
+++ b/ext/gda/extconf.rb
@@ -7,11 +7,11 @@ ENV['PKG_CONFIG_PATH'] ||= '/usr/local/lib/pkgconfig'
 dir_config 'libgda'
 
 def asplode missing
-  abort <<-MSG
-#{missing} is missing. Try 'brew install pkg-config libgda' if you are on OSX and have homebrew installed.
-You can also check https://github.com/GNOME/libgda for more info on how to install
-the dependency.
-MSG
+  abort <<~MSG
+    #{missing} is missing. Try 'brew install pkg-config libgda' if you are on OSX and have homebrew installed.
+    You can also check https://github.com/GNOME/libgda for more info on how to install
+    the dependency.
+  MSG
 end
 
 available_libgda_pkg_config = nil

--- a/lib/gda/visitors/dot.rb
+++ b/lib/gda/visitors/dot.rb
@@ -32,19 +32,19 @@ module GDA
         @buffer.printf(*args)
       end
 
-      NODE = ERB.new <<-eoerb
-node<%= node.object_id %> [shape="plaintext" label=<
-<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4">
-<TR><TD COLSPAN="2"><%= node.class %></TD></TR>
-<% attrs.each do |attr| %>
-  <% next if node.send(attr).nil? %>
-  <TR><TD><%= ERB::Util.h attr %></TD><TD><%= ERB::Util.h node.send(attr) %></TD></TR>
-<% end %>
-</TABLE>>];
+      NODE = ERB.new <<~eoerb
+        node<%= node.object_id %> [shape="plaintext" label=<
+        <TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4">
+        <TR><TD COLSPAN="2"><%= node.class %></TD></TR>
+        <% attrs.each do |attr| %>
+          <% next if node.send(attr).nil? %>
+          <TR><TD><%= ERB::Util.h attr %></TD><TD><%= ERB::Util.h node.send(attr) %></TD></TR>
+        <% end %>
+        </TABLE>>];
       eoerb
 
-      LIST = ERB.new <<-eoerb
-node<%= node.object_id %> [shape="invhouse", color=gray, fontcolor=gray, label=list];
+      LIST = ERB.new <<~eoerb
+        node<%= node.object_id %> [shape="invhouse", color=gray, fontcolor=gray, label=list];
       eoerb
 
       def add_node node, attrs = []

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -7,11 +7,11 @@ module GDA
 
       def setup
         @parser = GDA::SQL::Parser.new
-        sql = <<-SQL.gsub(/^ */, "")
-            SELECT id FROM posts WHERE actor_id = 1 AND actor_type = 1
-            UNION
-            SELECT id FROM posts WHERE actor_id = 1 AND actor_type = 3
-          SQL
+        sql = <<~SQL.gsub(/^ */, "")
+          SELECT id FROM posts WHERE actor_id = 1 AND actor_type = 1
+          UNION
+          SELECT id FROM posts WHERE actor_id = 1 AND actor_type = 3
+        SQL
 
         @stmt = parser.parse(sql)
       end


### PR DESCRIPTION
I'm brand new to this repo. I was searching for something else and found the heredoc with `brew install` instructions and noticed it was using the negative left column alignment older style, from Ruby days of yore.

I don't know of any reason why this change wouldn't Just Work™, but i don't know what i don't know. And I don't know this repo.

If it won't work, feel free to tell me that this won't work for reasons, and close out my PR. 🤙🏻