### PR TITLE
Convert GDA objects to TypedData API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gda (1.1.0.20190320134558)
+    gda (1.1.4)
 
 GEM
   remote: https://rubygems.org/
@@ -13,7 +13,8 @@ GEM
     sqlite3 (1.4.2)
 
 PLATFORMS
-  x86_64-darwin-21
+  arm64-darwin
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/ext/gda/gda.h
+++ b/ext/gda/gda.h
@@ -11,6 +11,9 @@ extern VALUE mSQL;
 extern VALUE cStatement;
 extern VALUE cParser;
 
+GdaStatement *gda_statement_unwrap(VALUE stmt);
+VALUE gda_parser_wrap(VALUE klass, GdaSqlParser * parser);
+
 #include <gda_statement.h>
 #include <gda_nodes.h>
 #include <gda_provider.h>

--- a/ext/gda/gda_nodes.c
+++ b/ext/gda/gda_nodes.c
@@ -25,11 +25,23 @@ VALUE cRollback;
 VALUE cCommit;
 VALUE cCompound;
 
+static const rb_data_type_t any_part_type = {
+    "GDA::SQL::AnyPart",
+    {
+        NULL,
+        NULL,
+        NULL,
+    },
+    0,
+    0,
+    RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+};
+
 #define WrapInteger(klass, type, lname) \
     static VALUE rb_##klass##_##lname(VALUE self) \
 { \
     type *st;\
-    Data_Get_Struct(self, type, st); \
+    TypedData_Get_Struct(self, type, &any_part_type, st); \
     return INT2NUM(st->lname); \
 }
 
@@ -37,7 +49,7 @@ VALUE cCompound;
     static VALUE rb_##klass##_##lname(VALUE self) \
 { \
     type *st;\
-    Data_Get_Struct(self, type, st); \
+    TypedData_Get_Struct(self, type, &any_part_type, st); \
     if (st->lname) \
       return Qtrue; \
     else \
@@ -48,7 +60,7 @@ VALUE cCompound;
     static VALUE rb_##klass##_##lname(VALUE self) \
 { \
     type *st;\
-    Data_Get_Struct(self, type, st); \
+    TypedData_Get_Struct(self, type, &any_part_type, st); \
     if (st->lname) \
       return rb_str_new2(st->lname); \
     else \
@@ -60,7 +72,7 @@ VALUE cCompound;
 { \
     type *st;\
     VALUE stmt;\
-    Data_Get_Struct(self, type, st); \
+    TypedData_Get_Struct(self, type, &any_part_type, st); \
     stmt = rb_iv_get(self, "stmt"); \
     return WrapAnyPart(stmt, (GdaSqlAnyPart *)st->lname); \
 }
@@ -72,7 +84,7 @@ VALUE cCompound;
     GSList *list; \
     VALUE rb_list; \
     VALUE stmt; \
-    Data_Get_Struct(self, type, ptr);\
+    TypedData_Get_Struct(self, type, &any_part_type, ptr);\
     stmt = rb_iv_get(self, "stmt"); \
     rb_list = rb_ary_new(); \
     list = ptr->lname; \
@@ -155,7 +167,7 @@ static VALUE distinct_p(VALUE self)
 {
     GdaSqlStatementSelect * st;
 
-    Data_Get_Struct(self, GdaSqlStatementSelect, st);
+    TypedData_Get_Struct(self, GdaSqlStatementSelect, &any_part_type, st);
 
     if (st->distinct)
 	return Qtrue;
@@ -165,7 +177,7 @@ static VALUE distinct_p(VALUE self)
 
 static VALUE Wrap(VALUE stmt, VALUE klass, GdaSqlAnyPart *part)
 {
-    VALUE obj = Data_Wrap_Struct(klass, NULL, NULL, part);
+    VALUE obj = TypedData_Wrap_Struct(klass, &any_part_type, part);
     rb_iv_set(obj, "stmt", stmt);
     return obj;
 }
@@ -256,7 +268,7 @@ static VALUE rb_cCompound_stmt_list(VALUE self)
     VALUE array;
     VALUE stmt;
 
-    Data_Get_Struct(self, GdaSqlStatementCompound, st);
+    TypedData_Get_Struct(self, GdaSqlStatementCompound, &any_part_type, st);
     stmt = rb_iv_get(self, "stmt");
     array = rb_ary_new();
 
@@ -276,7 +288,7 @@ static VALUE rb_cInsert_values_list(VALUE self)
     VALUE array;
     VALUE stmt;
 
-    Data_Get_Struct(self, GdaSqlStatementInsert, st);
+    TypedData_Get_Struct(self, GdaSqlStatementInsert, &any_part_type, st);
 
     stmt = rb_iv_get(self, "stmt");
 
@@ -302,7 +314,7 @@ static VALUE rb_cOperation_operator(VALUE self)
 {
     GdaSqlOperation * st;
 
-    Data_Get_Struct(self, GdaSqlOperation, st);
+    TypedData_Get_Struct(self, GdaSqlOperation, &any_part_type, st);
 
     if (st->operator_type)
 	return rb_str_new2(gda_sql_operation_operator_to_string(st->operator_type));
@@ -314,7 +326,7 @@ static VALUE rb_cJoin_join_type(VALUE self)
 {
     GdaSqlSelectJoin * st;
 
-    Data_Get_Struct(self, GdaSqlSelectJoin, st);
+    TypedData_Get_Struct(self, GdaSqlSelectJoin, &any_part_type, st);
 
     if (st->type)
 	return rb_str_new2(gda_sql_select_join_type_to_string(st->type));
@@ -326,7 +338,7 @@ static VALUE rb_st_type(VALUE self)
 {
     GdaSqlAnyPart * st;
 
-    Data_Get_Struct(self, GdaSqlAnyPart, st);
+    TypedData_Get_Struct(self, GdaSqlAnyPart, &any_part_type, st);
 
     switch(st->type) {
 	case GDA_SQL_ANY_STMT_BEGIN:
@@ -356,7 +368,7 @@ static VALUE rb_st_isolation_level(VALUE self)
 {
     GdaSqlStatementTransaction * st;
 
-    Data_Get_Struct(self, GdaSqlStatementTransaction, st);
+    TypedData_Get_Struct(self, GdaSqlStatementTransaction, &any_part_type, st);
 
     switch(st->isolation_level) {
 	default:
@@ -382,7 +394,7 @@ static VALUE rb_st_trans_mode(VALUE self)
 {
     GdaSqlStatementTransaction * st;
 
-    Data_Get_Struct(self, GdaSqlStatementTransaction, st);
+    TypedData_Get_Struct(self, GdaSqlStatementTransaction, &any_part_type, st);
 
     if (st->trans_mode)
 	return rb_str_new2(st->trans_mode);
@@ -394,7 +406,7 @@ static VALUE rb_st_trans_name(VALUE self)
 {
     GdaSqlStatementTransaction * st;
 
-    Data_Get_Struct(self, GdaSqlStatementTransaction, st);
+    TypedData_Get_Struct(self, GdaSqlStatementTransaction, &any_part_type, st);
 
     if (st->trans_name)
 	return rb_str_new2(st->trans_name);
@@ -407,7 +419,7 @@ static VALUE rb_cExpr_value(VALUE self)
     GdaSqlExpr * st;
     GValue * val;
 
-    Data_Get_Struct(self, GdaSqlExpr, st);
+    TypedData_Get_Struct(self, GdaSqlExpr, &any_part_type, st);
 
     val = st->value;
 

--- a/ext/gda/gda_provider.c
+++ b/ext/gda/gda_provider.c
@@ -2,10 +2,22 @@
 
 VALUE cProvider;
 
+static const rb_data_type_t provider_type = {
+    "GDA::SQL::Provider",
+    {
+        NULL,
+        NULL,
+        NULL,
+    },
+    0,
+    0,
+    RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+};
+
 static VALUE name(VALUE self)
 {
     GdaServerProvider * pr;
-    Data_Get_Struct(self, GdaServerProvider, pr);
+    TypedData_Get_Struct(self, GdaServerProvider, &provider_type, pr);
 
     return rb_str_new2(gda_server_provider_get_name(pr));
 }
@@ -18,7 +30,7 @@ static VALUE find(VALUE klass, VALUE string)
     pr = gda_config_get_provider(StringValuePtr(string), &error);
 
     if (pr)
-	return Data_Wrap_Struct(klass, NULL, NULL, pr);
+	return TypedData_Wrap_Struct(klass, &provider_type, pr);
     else {
 	/* FIXME: should actually raise an error here. */
 	g_error_free(error);
@@ -31,27 +43,29 @@ static VALUE parser(VALUE self)
     GdaSqlParser * parser;
     GdaServerProvider * pr;
 
-    Data_Get_Struct(self, GdaServerProvider, pr);
+    TypedData_Get_Struct(self, GdaServerProvider, &provider_type, pr);
 
     parser = gda_server_provider_create_parser(pr, NULL);
 
     if (!parser)
 	rb_raise(rb_eRuntimeError, "zomglol");
 
-    return Data_Wrap_Struct(cParser, NULL, g_object_unref, parser);
+    return gda_parser_wrap(cParser, parser);
 }
 
 static VALUE quote_str(VALUE self, VALUE str)
 {
     GdaServerProvider * pr;
 
-    Data_Get_Struct(self, GdaServerProvider, pr);
+    TypedData_Get_Struct(self, GdaServerProvider, &provider_type, pr);
     return rb_str_new2(gda_sql_identifier_quote(StringValuePtr(str), NULL, pr, TRUE, TRUE));
 }
 
 void Init_gda_provider()
 {
+    rb_global_variable(&cProvider);
     cProvider = rb_define_class_under(mSQL, "Provider", rb_cObject);
+
     rb_undef_alloc_func(cProvider);
     rb_define_singleton_method(cProvider, "find", find, 1);
     rb_define_method(cProvider, "name", name, 0);

--- a/ext/gda/gda_statement.c
+++ b/ext/gda/gda_statement.c
@@ -3,12 +3,32 @@
 VALUE cStatement;
 VALUE cStructure;
 
+static void structure_free(void *data)
+{
+    gda_sql_statement_free((GdaSqlStatement *)data);
+}
+
+static size_t structure_memsize(const void *data)
+{
+    return sizeof(GdaSqlStatement);
+}
+
+static const rb_data_type_t structure_type = {
+    "GDA::SQL::Structure",
+    {
+        NULL,
+        structure_free,
+        structure_memsize,
+    },
+    0,
+    0,
+    RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+};
+
 static VALUE serialize(VALUE self)
 {
-    GdaStatement * stmt;
+    GdaStatement * stmt = gda_statement_unwrap(self);
     gchar * string;
-
-    Data_Get_Struct(self, GdaStatement, stmt);
 
     string = gda_statement_serialize(stmt);
     return rb_str_new2(string);
@@ -17,36 +37,33 @@ static VALUE serialize(VALUE self)
 static VALUE ast(VALUE self)
 {
     GdaSqlStatement * sqlst;
-
-    Data_Get_Struct(self, GdaSqlStatement, sqlst);
-
+    TypedData_Get_Struct(self, GdaSqlStatement, &structure_type, sqlst);
     return WrapAnyPart(self, GDA_SQL_ANY_PART(sqlst->contents));
 }
 
 static VALUE sql(VALUE self)
 {
     GdaSqlStatement * sqlst;
-
-    Data_Get_Struct(self, GdaSqlStatement, sqlst);
-
+    TypedData_Get_Struct(self, GdaSqlStatement, &structure_type, sqlst);
     return rb_str_new2(sqlst->sql);
 }
 
 static VALUE structure(VALUE self)
 {
-    GdaStatement * stmt;
+    GdaStatement * stmt = gda_statement_unwrap(self);
     GdaSqlStatement * sqlst;
-
-    Data_Get_Struct(self, GdaStatement, stmt);
 
     g_object_get(G_OBJECT(stmt), "structure", &sqlst, NULL);
 
-    return Data_Wrap_Struct(cStructure, NULL, gda_sql_statement_free, sqlst);
+    return TypedData_Wrap_Struct(cStructure, &structure_type, sqlst);
 }
 
 void Init_gda_statement()
 {
+    rb_global_variable(&cStatement);
     cStatement = rb_define_class_under(mSQL, "Statement", rb_cObject);
+
+    rb_global_variable(&cStructure);
     cStructure = rb_define_class_under(mSQL, "Structure", rb_cObject);
 
     rb_undef_alloc_func(cStatement);


### PR DESCRIPTION
The replacement API was introduced in Ruby 1.9.2 (2010), and the old untyped data API was marked a deprecated in the documentation as of Ruby 2.3.0 (2015)

Ref: https://bugs.ruby-lang.org/issues/19998

@tenderlove 