### PR TITLE
Fix compatibility with newer Minitest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,22 @@
 PATH
   remote: .
   specs:
-    gda (1.1.0.20190320134558)
+    gda (1.1.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (5.15.0)
-    rake (13.0.6)
-    rake-compiler (1.1.7)
+    minitest (5.20.0)
+    rake (13.1.0)
+    rake-compiler (1.2.5)
       rake
-    sqlite3 (1.4.2)
+    sqlite3 (1.6.9-arm64-darwin)
+    sqlite3 (1.6.9-x86_64-darwin)
+    sqlite3 (1.6.9-x86_64-linux)
 
 PLATFORMS
-  x86_64-darwin-21
+  arm64-darwin
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,7 +3,7 @@ require 'gda'
 require 'sqlite3'
 
 module GDA
-  class TestCase < MiniTest::Test
+  class TestCase < Minitest::Test
     @@rails_sql = nil
 
     def self.rails_sql


### PR DESCRIPTION
Fixes:

```
/home/runner/work/gda/gda/test/helper.rb:6:in `<module:GDA>': uninitialized constant GDA::MiniTest (NameError)

  class TestCase < MiniTest::Test
                   ^^^^^^^^
Did you mean?  Minitest
```

@tenderlove 